### PR TITLE
Corrected strength/weakness modification math to match 1.9's mechanic changes.

### DIFF
--- a/src/main/java/com/github/maxopoly/finale/ConfigParser.java
+++ b/src/main/java/com/github/maxopoly/finale/ConfigParser.java
@@ -51,10 +51,10 @@ public class ConfigParser {
 		Double splashHealth = config.contains("gameplay.splashHealthModifier") ? config.getDouble("gameplay.splashHealthModifier", 0.0d) : null;
 
 		Integer strengthMultiplier = config.contains("gameplay.strengthMultiplier") ? config.getInt("gameplay.strengthMultiplier", 0) : null;
-		
+		Integer weaknessMultiplier = config.contains("gameplay.weaknessMultiplier") ? config.getInt("gameplay.weaknessMultiplier", 0) : null;
 		// Initialize the manager
 		manager = new FinaleManager(debug, attackEnabled, attackSpeed, regenEnabled, regenhandler, weapMod, disabledEnchants, splashHealth,
-				strengthMultiplier);
+				strengthMultiplier, weaknessMultiplier);
 		return manager;
 	}
 

--- a/src/main/java/com/github/maxopoly/finale/FinaleManager.java
+++ b/src/main/java/com/github/maxopoly/finale/FinaleManager.java
@@ -21,10 +21,11 @@ public class FinaleManager {
 	private Double splashHealth;
 	
 	private Integer strengthMultiplier;
+	private Integer weaknessMultiplier;
 	
 	public FinaleManager(boolean debug, boolean attackSpeedEnabled, double attackSpeed, boolean regenHandlerEnabled,
 			SaturationHealthRegenHandler regenHandler,WeaponModifier weaponModifier, Collection <Enchantment> disabledEnchants,
-			Double splashHealth, Integer strengthMultiplier) {
+			Double splashHealth, Integer strengthMultiplier, Integer weaknessMultiplier) {
 		this.attackSpeedEnabled = attackSpeedEnabled;
 		this.attackSpeed = attackSpeed;
 		this.regenHandlerEnabled = regenHandlerEnabled;
@@ -33,6 +34,7 @@ public class FinaleManager {
 		this.disabledEnchantments = disabledEnchants;
 		this.splashHealth = splashHealth;
 		this.strengthMultiplier = strengthMultiplier;
+		this.weaknessMultiplier = weaknessMultiplier;
 	}
 	
 	public boolean isDebug() {
@@ -69,5 +71,9 @@ public class FinaleManager {
 	
 	public Integer getStrengthMultiplier() {
 		return strengthMultiplier;
+	}
+
+	public Integer getWeaknessMultiplier() {
+		return weaknessMultiplier;
 	}
 }

--- a/src/main/java/com/github/maxopoly/finale/listeners/PlayerListener.java
+++ b/src/main/java/com/github/maxopoly/finale/listeners/PlayerListener.java
@@ -120,10 +120,11 @@ public class PlayerListener implements Listener {
 	}
 	
 	// ================================================
-	// Changes Strength Potions, strength_multiplier 3 is roughly Pre-1.6 Level
+	// Changes Strength Potions, updated for 1.9+ mechanics.
+	// Multiplier highly recommended for Civ servers.
 
 	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-	public void onPlayerDamage(EntityDamageByEntityEvent event) {
+	public void onPlayerStrengthDamage(EntityDamageByEntityEvent event) {
 		Integer strengthMultiplier = manager.getStrengthMultiplier();
 		if (strengthMultiplier == null) {
 			return;
@@ -137,8 +138,8 @@ public class PlayerListener implements Listener {
 			for (PotionEffect effect : player.getActivePotionEffects()) {
 				if (effect.getType().equals(PotionEffectType.INCREASE_DAMAGE)) {
 					final int potionLevel = effect.getAmplifier() + 1;
-					final double unbuffedDamage = event.getDamage() / (1.3 * potionLevel + 1);
-					final double newDamage = unbuffedDamage + (potionLevel * strengthMultiplier);
+					final double unbuffedDamage = event.getDamage() - (3 * potionLevel);
+					final double newDamage = unbuffedDamage + (strengthMultiplier * potionLevel);
 					event.setDamage(newDamage);
 					break;
 				}
@@ -146,6 +147,33 @@ public class PlayerListener implements Listener {
 		}
 	}
 	
+	// ================================================
+	// Changes Weakness Potions, updated for 1.9+ mechanics.
+
+	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+	public void onPlayerWeaknessDamage(EntityDamageByEntityEvent event) {
+		Integer weaknessMultiplier = manager.getWeaknessMultiplier();
+		if (weaknessMultiplier == null) {
+			return;
+		}
+		if (!(event.getDamager() instanceof Player)) {
+			return;
+		}
+		Player player = (Player) event.getDamager();
+		
+		if (player.hasPotionEffect(PotionEffectType.WEAKNESS)) {
+			for (PotionEffect effect : player.getActivePotionEffects()) {
+				if (effect.getType().equals(PotionEffectType.WEAKNESS)) {
+					final int potionLevel = effect.getAmplifier() + 1;
+					final double undebuffedDamage = event.getDamage() + (4 * potionLevel);
+					final double newDamage = undebuffedDamage + (potionLevel * weaknessMultiplier);
+					event.setDamage(newDamage);
+					break;
+				}
+			}
+		}
+	}
+	 
 	//@EventHandler
 	public void arrowHit(EntityDamageByEntityEvent e) {
 		if (!(e.getEntity() instanceof LivingEntity)) {

--- a/src/main/java/com/github/maxopoly/finale/listeners/PlayerListener.java
+++ b/src/main/java/com/github/maxopoly/finale/listeners/PlayerListener.java
@@ -166,7 +166,7 @@ public class PlayerListener implements Listener {
 				if (effect.getType().equals(PotionEffectType.WEAKNESS)) {
 					final int potionLevel = effect.getAmplifier() + 1;
 					final double undebuffedDamage = event.getDamage() + (4 * potionLevel);
-					final double newDamage = undebuffedDamage + (potionLevel * weaknessMultiplier);
+					final double newDamage = undebuffedDamage - (potionLevel * weaknessMultiplier);
 					event.setDamage(newDamage);
 					break;
 				}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -21,8 +21,10 @@ pearls:
 gameplay:
 #  Modify how much each splash health heals. Don't specify or set to 0 to disable. Version specific, do some research.
 # splashHealthModifier: 0.0
-#  Integer reassignment of strength's impact; if set to 3, should approximate 1.6 strength. Do not assign at all to disable.
+#  Integer reassignment of strength's impact; this changed since 1.9, no clue what approximates pre-1.7. Do not assign at all to disable.
 # strengthMultiplier: 3
+#  Same as strength, except for weakness potions. Do not assign at all to disable.
+# weaknessMultiplier: 3
 
   
 #allows adjusting the attack damage of any item by its spigot material identifier


### PR DESCRIPTION
Added corresponding weakness modifier too (weakness is -4 hearts, multiplier of 10 would make that -10 hearts per hit).

Currently the strength reversion stuff tries to revert 1.7 style strength (+130/260% damage), except that all changed with 1.9 (+1.5/3 hearts). This multiplier provides control over that scaling, so a multiplier of 5 would yield +5/10 hearts per hit to an unarmored minebeing.

For people updating to this version, you're going to have to test this for an appropriate multiplier. You may find yourself setting it high.